### PR TITLE
Improve clustering by segmenting C&S vs other shots

### DIFF
--- a/Analysis.py
+++ b/Analysis.py
@@ -1,8 +1,13 @@
+import kmedoids
 import numpy as np
 import pandas as pd
 
+from itertools import combinations
+
 from matplotlib import pyplot as plt
 from sklearn import manifold
+from sklearn import cluster
+from sklearn.metrics import pairwise_distances
 
 
 def cumfreq(a, numbins=10, defaultreallimits=None):
@@ -235,30 +240,164 @@ def speedAnalysis():
 
 FEATURES_OF_INTEREST = [
 	'ShotClock', 'CnS', 'Points', 'TimeCns', 'v_CnS', 'dist_at_shot', 'shot_angle', 'shooter_move_angle',
-	'shooter_travel', 'def_dist_at_shot', 'def_avg_vel', 'speedBeforeCatch0.5s']
+	'shooter_travel', 'def_dist_at_shot', 'def_avg_vel', 'SpeedBeforeCatch0.5s']
 
 REDUCED_FEATURES = [
 	'def_dist_at_shot', 'shooter_travel', 'speedBeforeCatch0.5s', 'dist_at_shot', 'TimeCns']
 
-def clustering(threshold):
+CNS_FEATURES = [
+	'ShotClock', 'Points', 'TimeCns', 'v_CnS', 'dist_at_shot', 'shot_angle', 'shooter_move_angle',
+	'shooter_travel', 'def_dist_at_shot', 'def_avg_vel', 'SpeedBeforeCatch0.5s']
+
+OTHER_FEATURES = [
+	'ShotClock', 'Points', 'TimeCns', 'v_CnS', 'dist_at_shot', 'shot_angle', 'shooter_move_angle',
+	'shooter_travel', 'def_dist_at_shot', 'def_avg_vel']
+
+def generatePlayerMeans(threshold):
 	X = pd.read_csv('threes.csv', header=0)
 	shooters = set(X['ShooterID'])
-	shooterMeans = pd.DataFrame(columns=X.columns)
+
+	cnsCols = ['CnS_{}'.format(name) for name in CNS_FEATURES]
+	otherCols = ['nonCnS_{}'.format(name) for name in OTHER_FEATURES]
+	featureCols = ['shooterID', 'pctCnS']
+	allCols = cnsCols + otherCols + featureCols
+
+	shooterMeans = pd.DataFrame(columns=allCols)
 
 	for shooterID in shooters:
 		shooterX = X.loc[X['ShooterID']==shooterID]
 		if len(shooterX) >= threshold:
-			shooterMean = np.mean(shooterX)
-			shooterMeans.append(shooterMean, ignore_index=True)
 
-	XTSNE = manifold.TSNE().fit_transform(shooterMeans[FEATURES_OF_INTEREST])
-	XMDS = manifold.MDS().fit_transform(shooterMeans[FEATURES_OF_INTEREST])
+			shooterCnS = shooterX.loc[shooterX['CnS']==True]
+			shooterCnS = shooterCnS[CNS_FEATURES]
+			shooterCnS.columns = cnsCols
 
-	x = [row[0] for row in XTSNE]
-	y = [row[1] for row in XTSNE]
+			shooterOther = shooterX.loc[shooterX['CnS']==False]
+			shooterOther = shooterOther[OTHER_FEATURES]
+			shooterOther.columns = otherCols
+
+			meanCnS = np.mean(shooterCnS)
+			meanOther = np.mean(shooterOther)
+			moreFeatures = pd.Series({
+				'shooterID': shooterID,
+				'pctCnS': len(shooterCnS) / (len(shooterCnS) + len(shooterOther))
+				})
+			shooterMean = pd.concat([moreFeatures, meanCnS, meanOther], axis=0)
+			# print(shooterMean)
+			if not shooterMean.hasnans:
+				shooterMeans = shooterMeans.append(shooterMean, ignore_index=True)
+
+	return shooterMeans
+
+def clusterPlayerMeans(shooterMeans, max_clusters=10):
+	clusterings = list()
+	performances = list()
+
+	for k in range(1, max_clusters+1):
+		print(k)
+		kmeans = cluster.KMeans(n_clusters=k)
+		labels = kmeans.fit_predict(shooterMeans)
+		wgss = 0
+		for label in range(k):
+			indices = np.nonzero(labels==label)[0]
+			for combo in combinations(indices, 2):
+				v1 = shooterMeans.loc[combo[0]]
+				v2 = shooterMeans.loc[combo[1]]
+				d = [v1[name] - v2[name] for name in shooterMeans.columns]
+				dist = np.linalg.norm(d)**2
+				wgss += dist
+
+		clusterings.append(labels)
+		performances.append(wgss)
+
+	return clusterings, performances
+
+def clusterKMedoids(shooterMeans, max_clusters=10):
+	medoids = list()
+	clusterings = list()
+	performances = list()
+	n, _ = shooterMeans.shape
+	D = pairwise_distances(shooterMeans)
+
+	for k in range(1,max_clusters+1):
+		print(k)
+		m, c = kmedoids.kMedoids(D, k, 10000)
+
+		medoids.append(m)
+
+		# Cluster output of kMedoids is dictionary {cid: [x where c(x)==cid]}
+		# Transform to list of cluster id for similarity with kMeans
+		labels = [-1] * n
+		for label in c:
+			for idx in c[label]:
+				labels[idx] = label
+
+		labels = np.array(labels) # Transform so that np.nonzero works
+
+		wgss = 0
+		for label in range(k):
+			indices = np.nonzero(labels==label)[0]
+			for combo in combinations(indices, 2):
+				v1 = shooterMeans.loc[combo[0]]
+				v2 = shooterMeans.loc[combo[1]]
+				d = [v1[name] - v2[name] for name in shooterMeans.columns]
+				dist = np.linalg.norm(d)**2
+				wgss += dist
+
+		clusterings.append(labels)
+		performances.append(wgss)
+
+	return clusterings, performances, medoids
+
+
+def plotClusters(shooterMeans, clusters=None, method='MDS', labels=None):
+	transformer = None
+	if method == 'MDS':
+		transformer = manifold.MDS()
+	elif method == 'TSNE':
+		transformer = manifold.TSNE()
+	else:
+		raise ValueError('Method can be either \'MDS\' or \'TSNE\'')
+
+	features = list(shooterMeans.columns)
+	features.remove('shooterID')
+
+	X = transformer.fit_transform(shooterMeans[features])
+
+	x = [row[0] for row in X]
+	y = [row[1] for row in X]
 	fig, ax = plt.subplots()
-	ax.scatter(x, y)
-	for i, row in shooterMeans.iterrows():
-		ax.annotate(int(row['ShooterID']), (x[i], y[i]))
+	if clusters is not None:
+		ax.scatter(x, y, c=clusters)
+	else:
+		ax.scatter(x, y)
+
+	# Labels specify which players to identify with their shooter ID in the plot
+	# Will replace with name in the future
+	for idx in labels:
+		row = shooterMeans.loc[idx]
+		ax.annotate(int(row['shooterID']), (x[idx], y[idx]))
 
 	plt.show()
+
+def main():
+	D = generatePlayerMeans(60)
+
+	features = list(D.columns)
+	features.remove('shooterID') # DON'T RUN CLUSTERING ON PLAYER ID!
+
+	max_clusters = 10
+
+	c, p = clusterPlayerMeans(D[features], max_clusters=max_clusters)
+	cm, pm, m = clusterKMedoids(D[features], max_clusters=max_clusters)
+
+	# plt.plot(list(range(1, max_clusters+1)), pm)
+	# plt.show()
+
+	# Seems that 3 clusters is the best (use k-medoids)
+	plotClusters(D, clusters=cm[2], labels=m[2])
+
+	return D, c, p, cm, pm, m
+
+if __name__ == '__main__':
+	main()

--- a/kmedoids.py
+++ b/kmedoids.py
@@ -1,0 +1,64 @@
+import numpy as np
+import random
+
+def kMedoids(D, k, tmax=100):
+    # determine dimensions of distance matrix D
+    m, n = D.shape
+
+    if k > n:
+        raise Exception('too many medoids')
+
+    # find a set of valid initial cluster medoid indices since we
+    # can't seed different clusters with two points at the same location
+    valid_medoid_inds = set(range(n))
+    invalid_medoid_inds = set([])
+    rs,cs = np.where(D==0)
+    # the rows, cols must be shuffled because we will keep the first duplicate below
+    index_shuf = list(range(len(rs)))
+    np.random.shuffle(index_shuf)
+    rs = rs[index_shuf]
+    cs = cs[index_shuf]
+    for r,c in zip(rs,cs):
+        # if there are two points with a distance of 0...
+        # keep the first one for cluster init
+        if r < c and r not in invalid_medoid_inds:
+            invalid_medoid_inds.add(c)
+    valid_medoid_inds = list(valid_medoid_inds - invalid_medoid_inds)
+
+    if k > len(valid_medoid_inds):
+        raise Exception('too many medoids (after removing {} duplicate points)'.format(
+            len(invalid_medoid_inds)))
+
+    # randomly initialize an array of k medoid indices
+    M = np.array(valid_medoid_inds)
+    np.random.shuffle(M)
+    M = np.sort(M[:k])
+
+    # create a copy of the array of medoid indices
+    Mnew = np.copy(M)
+
+    # initialize a dictionary to represent clusters
+    C = {}
+    for t in range(tmax):
+        # determine clusters, i. e. arrays of data indices
+        J = np.argmin(D[:,M], axis=1)
+        for kappa in range(k):
+            C[kappa] = np.where(J==kappa)[0]
+        # update cluster medoids
+        for kappa in range(k):
+            J = np.mean(D[np.ix_(C[kappa],C[kappa])],axis=1)
+            j = np.argmin(J)
+            Mnew[kappa] = C[kappa][j]
+        np.sort(Mnew)
+        # check for convergence
+        if np.array_equal(M, Mnew):
+            break
+        M = np.copy(Mnew)
+    else:
+        # final update of cluster memberships
+        J = np.argmin(D[:,M], axis=1)
+        for kappa in range(k):
+            C[kappa] = np.where(J==kappa)[0]
+
+    # return results
+    return M, C


### PR DESCRIPTION
Separates catch-and-shoot from off-dribble 3-pt shots which
leads to better clustering outcomes.

Adds code to cluster players based on 3 pt shooting, both in k-Means
and k-Medoids.

Adds plotting functions